### PR TITLE
Change a setting parameter of the NSST model in UFS_UTILS to be consistent with UFS(fv3atm)

### DIFF
--- a/sorc/chgres_cube.fd/surface.F90
+++ b/sorc/chgres_cube.fd/surface.F90
@@ -2679,7 +2679,7 @@
  integer(esmf_kind_i8), pointer     :: mask_ptr(:,:)
  integer                            :: rc,i
  integer, PARAMETER                 :: num_nst_fields_minus2 = 16
- integer, PARAMETER                 :: xz_fill = 30.0
+ integer, PARAMETER                 :: xz_fill = 20.0
  integer, PARAMETER                 :: nst_fill = 0.0
 
  real(esmf_kind_r8), pointer        :: data_ptr(:,:)
@@ -2738,6 +2738,7 @@
 
  where(mask_ptr == 0) data_ptr = xz_fill ! all land
  where(fice_ptr > 0.0) data_ptr = xz_fill ! points with some ice
+ where(data_ptr > xz_fill ) data_ptr = xz_fill ! force xz = 20 when it is greater than 20 (due to fv3atm code change) 
 
  do i = 1,num_nst_fields_minus2
    


### PR DESCRIPTION
A NSST model parameter, the maximum value of the diurnal warming layer thickness, z_w_max, has been reduced from 30 to 20 meters in 2021 in UFS (fv3atm) code, but z_w_max or xz_fill in UFS_UTILS is still set to be 30 in the chgres_cube utility of in UFS_UTILS. This PR is to change it to be 20 in UFS_UTILS as well to be consistent to UFS. 

The code has been modifed and tested, and the result is as expected. The branch created: chgres_xz. 

See UFS_UTILS issue: https://github.com/ufs-community/UFS_UTILS/issues/1107

See  https://docs.google.com/document/d/1Fl_rw_ski4cbP70I601uHhW7KNSwGB20Nf3UlJnsve4/edit?tab=t.0 for the details of the concern and solution. 

ufs-community/UFS_UTILS/pull/1



